### PR TITLE
fix(ci): remove charmhub token requirement for build-and-test

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,8 +15,6 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/build-and-test.yaml
-    secrets:
-      CHARMHUB_TOKEN: "${{ secrets.CHARMHUB_TOKEN }}"
 
   release-to-charmhub:
     name: Release to CharmHub

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -23,4 +23,4 @@ async def test_can_build_charm(ops_test: OpsTest):
     """
     # Build and deploy charm from local source folder
     charm = await ops_test.build_charm(".")
-    assert not charm
+    assert charm


### PR DESCRIPTION
The `buid-and-test` job errored as it did not require a `CHARMHUB_TOKEN` for any of the stages, so it has been removed.